### PR TITLE
Fix the API version parsing logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "JukeAudio"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Paul Karimov", email="paul_karimov@outlook.com" },
 ]


### PR DESCRIPTION
In the latest Juke Audio firmware the response content type for the /api request is specified twice - first as octet-stream and then as json. The first takes precedence, so aiohttp parsing fails. Even if that validation is turned off, the response is not valid json as it uses single quotes instead of doubles. Furthermore, previously the output contained the key 'versions' and now it is just an array of version numbers. This changes works around that.